### PR TITLE
Faster deploy

### DIFF
--- a/deploy
+++ b/deploy
@@ -1,4 +1,4 @@
-#!/bin/env sh
+#!/bin/sh
 
 # which server we're building (either "frontend" or "backend"
 SERVER="$1"

--- a/launch-backend.sh
+++ b/launch-backend.sh
@@ -1,20 +1,22 @@
 #!/usr/bin/env sh
 
-# force remove all containers
-echo "removing ALL containers..."
-docker rm --force $(docker ps -aq)
+# Repo and tag of the image we want to grab
+REPO="kenzieacademy"
+TAG="$1"
 
 
-# force remove all images
-echo "removing ALL images..."
-docker rmi --force $(docker images -q)
+# force stop front-end React container
+echo "killing React container..."
+docker rm --force oil-recycling-fe
+
+# update React image to latest
+echo "updating images..."
+docker pull "$REPO/oil-recycling-node:$TAG"
 
 
 # start a mongodb container
 docker run --name oil-recycling-db -d mongo:latest
 
-# Tag of the image we want to grab
-TAG="$1"
 
 # start backend container pointing to mongo container
 MONGO_HOST=$(docker inspect -f '{{.NetworkSettings.IPAddress}}' oil-recycling-db)

--- a/launch-backend.sh
+++ b/launch-backend.sh
@@ -7,7 +7,7 @@ TAG="$1"
 
 # force stop front-end React container
 echo "killing React container..."
-docker rm --force oil-recycling-fe
+docker rm --force oil-recycling-node oil-recycling-db
 
 # update React image to latest
 echo "updating images..."

--- a/launch-frontend.sh
+++ b/launch-frontend.sh
@@ -1,17 +1,18 @@
 #!/usr/bin/env sh
 
-# force remove all containers
-echo "removing ALL containers..."
-docker rm --force $(docker ps -aq)
-
-
-# force remove all images
-echo "removing ALL images..."
-docker rmi --force $(docker images -q)
-
-
-# Tag of the image we want to grab
+# Repo and tag of the image we want to grab
+REPO="kenzieacademy"
 TAG="$1"
+
+
+# force stop front-end React container
+echo "killing React container..."
+docker rm --force oil-recycling-fe
+
+# update React image to latest
+echo "updating images..."
+docker pull "$REPO/oil-recycling-project-fe:$TAG"
+
 
 BACKEND_API=http://18.219.106.221
 


### PR DESCRIPTION
# Description
I meant to do this a while ago. Rather than deleting all containers and images, we now just pull changes from latest image and rebuild the container. Doesn't make DockerHub any faster, unfortunately, but should make running the script faster.

I also made a slight modification to the `deploy` script. Basically, you shouldn't need to do`sh ./deploy frontend` anymore. You can just do `./deploy frontend`. Didn't document yet because I want to take it for a spin for a while and make sure there isn't any difference on the various versions of Mac and Linux we might run. (eg `sh ./deploy frontend` would work everywhere, I'm not sure if this is the case for the shorter version).