### PR TITLE
More deploy fixes

### DIFF
--- a/launch-backend.sh
+++ b/launch-backend.sh
@@ -20,4 +20,4 @@ docker run --name oil-recycling-db -d mongo:latest
 
 # start backend container pointing to mongo container
 MONGO_HOST=$(docker inspect -f '{{.NetworkSettings.IPAddress}}' oil-recycling-db)
-docker run -e MONGO_HOST=$MONGO_HOST --name oil-recycling-node -p 80:8080 -d kenzieacademy/oil-recycling-node:$TAG
+docker run -e MONGO_HOST=$MONGO_HOST -v /usr/src/app/data/db:/data/db --name oil-recycling-node -p 80:8080 -d kenzieacademy/oil-recycling-node:$TAG

--- a/launch-backend.sh
+++ b/launch-backend.sh
@@ -15,9 +15,9 @@ docker pull "$REPO/oil-recycling-node:$TAG"
 
 
 # start a mongodb container
-docker run --name oil-recycling-db -d mongo:latest
+docker run --name oil-recycling-db -v /usr/src/app/data/db:/data/db -d mongo:latest
 
 
 # start backend container pointing to mongo container
 MONGO_HOST=$(docker inspect -f '{{.NetworkSettings.IPAddress}}' oil-recycling-db)
-docker run -e MONGO_HOST=$MONGO_HOST -v /usr/src/app/data/db:/data/db --name oil-recycling-node -p 80:8080 -d kenzieacademy/oil-recycling-node:$TAG
+docker run -e MONGO_HOST=$MONGO_HOST --name oil-recycling-node -p 80:8080 -d kenzieacademy/oil-recycling-node:$TAG

--- a/launch-frontend.sh
+++ b/launch-frontend.sh
@@ -16,4 +16,4 @@ docker pull "$REPO/oil-recycling-project-fe:$TAG"
 
 BACKEND_API=http://18.219.106.221
 
-docker run -e REACT_APP_OIL_RECYCLING_API=$BACKEND_API --name oil-recycling-fe -p 80:3000 -d kenzieacademy/oil-recycling-project-fe:$TAG
+docker run -e NODE_ENV=production -e REACT_APP_OIL_RECYCLING_API=$BACKEND_API --name oil-recycling-fe -p 80:3000 -d kenzieacademy/oil-recycling-project-fe:$TAG /bin/bash -c "npm run build && npm install -g serve && serve -s build -p 3000"


### PR DESCRIPTION
# Description
Updated deployment tasks for both front and backend:
- for the front end, I made it so that a production build happens and a stand alone production server runs
- for the backend, I added a volume mount so that data in mongo isn't wiped every deployment

# Testing
1. For the front end -- call `./deploy frontend` as normal, and you should notice that things still work
2. For back end -- deploy once with `./deploy backend`, add a few accounts (perhaps using swagger ui), then redeploy. You should notice the old data remains