### PR TITLE
Updated backend deploy script

### DIFF
--- a/launch-backend.sh
+++ b/launch-backend.sh
@@ -20,4 +20,4 @@ docker run --name oil-recycling-db -v /usr/src/app/data/db:/data/db -d mongo:lat
 
 # start backend container pointing to mongo container
 MONGO_HOST=$(docker inspect -f '{{.NetworkSettings.IPAddress}}' oil-recycling-db)
-docker run -e MONGO_HOST=$MONGO_HOST --name oil-recycling-node -p 80:8080 -d kenzieacademy/oil-recycling-node:$TAG
+docker run -e MONGO_HOST=$MONGO_HOST --name oil-recycling-node -p 80:8080 -d kenzieacademy/oil-recycling-node:$TAG npm run prod


### PR DESCRIPTION
# Description
I changed the way the container runs to make development easier. As such, I needed to override the default command that runs so that a production server runs on the staging server.

# How to test
NA -- This will have to be tested _after_ [this](https://github.com/KenzieAcademy/oil-recycling-node/pull/14) PR. Once merged, you should be able to do `./deploy backend` as usual and not notice a difference.