### PR TITLE
Even more clean up

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,26 +8,21 @@ This repository contains a few scripts used to ease deployment:
 ## Examples
 To deploy backend containers:
 ```bash
-sh ./deploy backend /path/to/key-file/
+sh ./deploy backend <tag> </path/to/key-file/>
 ```
 
 To launch frontend containers:
 ```bash
-sh ./deploy frontend /path/to/key-file/
+sh ./deploy frontend <tag> </path/to/key-file/>
 ```
 
 To launch a given container with a specific tag:
 ```bash
-./deploy frontend /path/to/key-file/ some-tag
+./deploy frontend <tag> </path/to/key-file/>
 ```
 
 If ommitted, tag is assumed to be "latest". If the path to key-file is omitted,
 it is assumed to be a file named "kenzie-canvas.pem" in your current location.
-
-If you don't have the deployment repository cloned, you can execute a deployment
-using curl:
-
-The above will run frontend containers tagged "some-tag".
 
 ## When to Deploy
 
@@ -49,13 +44,13 @@ Once you ahve done so, you can deploy from your local machine. Once you've
 cloned this repository and `cd`ed into the root, you can deploy the frontend
 with:
 ```bash
-sh ./deploy frontend /path/to/key-file
+sh ./deploy frontend <tag> </path/to/key-file>
 ```
 
 And the backend with:
 
 ```bash
-sh ./deploy backend /path/to/key-file
+sh ./deploy backend <tag> </path/to/key-file>
 ```
 
 This repository ignores pem files, so feel free to copy the kenzie-canvas.pem file into the root of your local version of this repository. Deployment then becomes:

--- a/deploy
+++ b/deploy
@@ -4,11 +4,11 @@
 SERVER="$1"
 
 # key file
-KEY_FILE="$2"
+KEY_FILE="$3"
 KEY_FILE=${KEY_FILE:=kenzie-canvas.pem}
 
 # which tag to use when fetching the docker image
-TAG="$3"
+TAG="$2"
 TAG=${TAG:=latest}
 
 

--- a/launch-backend.sh
+++ b/launch-backend.sh
@@ -24,3 +24,6 @@ MONGO_HOST=$(docker inspect -f '{{.NetworkSettings.IPAddress}}' oil-recycling-db
 SUPER_USER_EMAIL=admin@kenzie.academy
 SUPER_USER_PASSWORD=password
 docker run -e MONGO_HOST=$MONGO_HOST -e SUPER_USER_EMAIL=$SUPER_USER_EMAIL -e SUPER_USER_PASSWORD=$SUPER_USER_PASSWORD --name oil-recycling-node -p 80:8080 -d kenzieacademy/oil-recycling-node:$TAG npm run prod
+
+echo "Removing old artifacts"
+docker system prune -af

--- a/launch-frontend.sh
+++ b/launch-frontend.sh
@@ -17,3 +17,6 @@ docker pull "$REPO/oil-recycling-project-fe:$TAG"
 BACKEND_API=http://18.219.106.221
 
 docker run -e NODE_ENV=production -e REACT_APP_OIL_RECYCLING_API=$BACKEND_API --name oil-recycling-fe -p 80:3000 -d kenzieacademy/oil-recycling-project-fe:$TAG /bin/bash -c "npm run build && npm install -g serve && serve -s build -p 3000"
+
+echo "Removing old artifacts"
+docker system prune -af


### PR DESCRIPTION
# Description
Updated deploy scripts to not only reclaim unused space left by old images, but also reorder commands.

# Testing
1. You should be able to deploy an arbitrary tag by not having to specify the pem file:
```./deploy frontend <some_tag>

2. You should see a comment about how much extra space was recovered