### PR TITLE
Simplified Deployment Scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,65 +1,37 @@
 # Deployment Scripts
-
 This repository contains a few scripts used to ease deployment:
 - launch-backend.sh: launches a backend container along with a mongo container to be accessed by the backend
 - launch-frontend.sh: launches a frontend container
 - deploy: takes three arguments: server to deploy, path to key file, and tag of container to deploy
 
-## Examples
-To deploy backend containers:
+# TL;DR
+Assuming you have the proper SSH keys added to your SSH agent (hint: if this
+sentence doesn't make sense, skip down to "How to Deploy") you can deploy the
+backend with:
+
 ```bash
-sh ./deploy backend <tag> </path/to/key-file/>
+./deploy backend <tag>
 ```
 
-To launch frontend containers:
+And the frontend with:
 ```bash
-sh ./deploy frontend <tag> </path/to/key-file/>
+sh ./deploy frontend <tag>
 ```
 
-To launch a given container with a specific tag:
-```bash
-./deploy frontend <tag> </path/to/key-file/>
-```
-
-If ommitted, tag is assumed to be "latest". If the path to key-file is omitted,
-it is assumed to be a file named "kenzie-canvas.pem" in your current location.
+If ommitted, tag is assumed to be "latest".
 
 ## When to Deploy
-
-The deploy script should be run any time updates need to be pushed to the backend
-or frontend servers. Any PR that gets merged into master for either repository
-will trigger a new build on DockerHub. That is, a new docker `image` will be
-built. The EC2 instance needs to then run a container from the updated image,
-which is what these scripts accomplish.
+These scripts should only be needed in cases where CircleCI failed to properly
+deploy, or cases when we want to manually deploy an old tag.
 
 # How to deploy.
-First, you'll need the "pem" key file from [this](https://github.com/KenzieAcademy/kenzie-canvas) repository. I typically just clone the entire repo and `cd` into the `credentials` directory. 
+First, you'll need the "pem" key file from
+[here]("https://raw.githubusercontent.com/KenzieAcademy/kenzie-canvas/master/credentials/kenzie-canvas.pem?token=AAFt9v-ioq73PU21YD1maAuFD7ocCdIkks5azJCnwA%3D%3D")
 
-You'll need to change the permissions of the "pem" file:
+You'll need to add that "pem" file (private key) to your ssh agent:
 ```bash
-chmod 400 kenzie-canvas.pem
+eval `ssh-agent -s`
+ssh-add kenzie-canvas.pem
 ```
 
-Once you ahve done so, you can deploy from your local machine. Once you've
-cloned this repository and `cd`ed into the root, you can deploy the frontend
-with:
-```bash
-sh ./deploy frontend <tag> </path/to/key-file>
-```
-
-And the backend with:
-
-```bash
-sh ./deploy backend <tag> </path/to/key-file>
-```
-
-This repository ignores pem files, so feel free to copy the kenzie-canvas.pem file into the root of your local version of this repository. Deployment then becomes:
-
-```bash
-sh ./deploy frontend
-```
-
-Or
-```bash
-sh ./deploy backend
-```
+Once you have done so, you can deploy from your local machine using the instructions above in "TL;DR".

--- a/deploy
+++ b/deploy
@@ -18,4 +18,4 @@ else
   exit 1
 fi
 
-ssh ec2-user@$IP "bash -s" -- < ./launch-$SERVER.sh $TAG
+ssh -oStrictHostKeyChecking=no ec2-user@$IP "bash -s" -- < ./launch-$SERVER.sh $TAG

--- a/deploy
+++ b/deploy
@@ -3,10 +3,6 @@
 # which server we're building (either "frontend" or "backend"
 SERVER="$1"
 
-# key file
-KEY_FILE="$3"
-KEY_FILE=${KEY_FILE:=kenzie-canvas.pem}
-
 # which tag to use when fetching the docker image
 TAG="$2"
 TAG=${TAG:=latest}
@@ -22,4 +18,4 @@ else
   exit 1
 fi
 
-ssh -i "$KEY_FILE" ec2-user@$IP "bash -s" -- < ./launch-$SERVER.sh $TAG
+ssh ec2-user@$IP "bash -s" -- < ./launch-$SERVER.sh $TAG


### PR DESCRIPTION
# Description
This PR has three purposes:
1. To make deployment instructions clearer
2. To make deployment itself easier
3. To make way for deployment via CircleCI

The first is done by drastically cutting out redundant elements from the `README.md` file, and optimizing the reading order such that those who have deployed before but forgot the commands can quickly get going, but those who have never done so can continue reading to get more details.

The second is done by assuming (and instructing developers on how) to add the `kenzie-canvas.pem` file to their ssh agent so that they don't always have to deploy from a directory that has that file in it. A future PR may include instructions on how to add `deploy` to your `$PATH`, which would mean being able to deploy from any arbitrary location on your machine, rather than only the deployment directory. 

The third will depend on separate PRs in the front and back end repositories, but is enabled by the first. 

# Steps to Test
1. RTFM
2. If, having done 1, you can deploy successfully, we're good to go [1].

[1] Please read the instructions _again_. Deployment is subtly different than before, so just doing exactly what you did before won't cut it here. Specifically, if you're attempting the instructions from a directory that has the `kenzie-canvas.pem` file in it, you _aren't_ testing this PR. 